### PR TITLE
Quick fix for UserLat and UserLng settings

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -61,9 +61,9 @@
     
     <property id="DarkFieldBackground" type="boolean">false</property>
     
-    <property id="UserLat" type="float">0.0</property>
+    <property id="UserLat" type="string">0.0</property>
     
-    <property id="UserLng" type="float">0.0</property>
+    <property id="UserLng" type="string">0.0</property>
     
     <property id="SunriseSunset" type="boolean">false</property>
     

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -271,11 +271,11 @@
     </setting>
          
     <setting propertyKey="@Properties.UserLat" title="@Strings.UserLat">
-    	<settingConfig type="numeric" required="true" />
+    	<settingConfig type="alphanumeric" required="true" />
     </setting>
     
     <setting propertyKey="@Properties.UserLng" title="@Strings.UserLng">
-    	<settingConfig type="numeric" required="true" />
+    	<settingConfig type="alphanumeric" required="true" />
     </setting>
     
     <setting propertyKey="@Properties.SunriseSunset" title="@Strings.SunriseSunset">


### PR DESCRIPTION
Fixed the issue on UserLat and UserLng settings when the language separator differs from ".".
Related to issue #10 (Input geographical data)